### PR TITLE
Add CLI tool for generating common size financial statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Commonize
+
+Commonize is a command line tool that retrieves public financial statement data from the U.S. Securities and Exchange Commission (SEC) and presents it as a common size statement. The project is designed to act as the foundation for a future web application that provides the same functionality.
+
+## Features
+
+- Convert balance sheets or income statements into common size format
+- Retrieve data directly from the SEC's XBRL API
+- Cache ticker-to-CIK mappings locally for faster repeated use
+- Friendly command line interface with optional GitHub-flavored markdown output
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Set a descriptive user agent via the `COMMONIZE_USER_AGENT` environment variable to comply with SEC rate limiting guidance.
+
+```bash
+export COMMONIZE_USER_AGENT="CommonizeApp/0.1 (contact@example.com)"
+```
+
+## Usage
+
+```bash
+python main.py AAPL --statement income --period annual
+```
+
+Available options:
+
+- `ticker`: Ticker symbol or CIK
+- `--statement`: `income` or `balance`
+- `--period`: `annual` or `quarterly`
+- `--force-refresh`: Refreshes the cached ticker metadata
+
+## Development roadmap
+
+1. **Local CLI (current stage)** – Fetch SEC data and render common size statements in the terminal.
+2. **API service** – Expose the functionality through a lightweight REST API.
+3. **Web application** – Build a front-end that calls the API and deploy both components to the cloud.
+4. **Automation & monitoring** – Add background jobs, logging, and observability to ensure reliability.
+
+Contributions and ideas are welcome!

--- a/commonize/__init__.py
+++ b/commonize/__init__.py
@@ -1,0 +1,26 @@
+"""Commonize package for generating common size financial statements."""
+from .common_size import (
+    CommonSizeLine,
+    StatementNotAvailableError,
+    build_balance_sheet,
+    build_income_statement,
+)
+from .cli import main as cli_main
+from .sec_client import (
+    SECClientError,
+    fetch_company_facts,
+    fetch_ticker_map,
+    resolve_cik,
+)
+
+__all__ = [
+    "CommonSizeLine",
+    "StatementNotAvailableError",
+    "SECClientError",
+    "build_balance_sheet",
+    "build_income_statement",
+    "cli_main",
+    "fetch_company_facts",
+    "fetch_ticker_map",
+    "resolve_cik",
+]

--- a/commonize/cli.py
+++ b/commonize/cli.py
@@ -1,0 +1,80 @@
+"""Command line interface for generating common size statements."""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Callable, Iterable, List
+
+from . import common_size, sec_client
+
+try:
+    from tabulate import tabulate
+except ImportError:  # pragma: no cover - fallback when tabulate not installed
+    tabulate = None  # type: ignore
+
+
+def _statement_builder(name: str) -> Callable[[dict, str], List[common_size.CommonSizeLine]]:
+    if name == "income":
+        return common_size.build_income_statement
+    if name == "balance":
+        return common_size.build_balance_sheet
+    raise ValueError(f"Unsupported statement type '{name}'.")
+
+
+def _render_table(lines: Iterable[common_size.CommonSizeLine]) -> str:
+    rows = [line.as_row() for line in lines]
+    headers = ["Line item", "Value (USD)", "Common size"]
+    if tabulate:
+        return tabulate(rows, headers=headers, tablefmt="github")
+    # Simple fallback rendering
+    column_widths = [max(len(str(row[i])) for row in rows + [headers]) for i in range(3)]
+    lines_out = [
+        " | ".join(h.ljust(column_widths[idx]) for idx, h in enumerate(headers)),
+        "-+-".join("-" * column_widths[idx] for idx in range(3)),
+    ]
+    for row in rows:
+        lines_out.append(" | ".join(str(cell).ljust(column_widths[idx]) for idx, cell in enumerate(row)))
+    return "\n".join(lines_out)
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate common size financial statements from SEC data.")
+    parser.add_argument("ticker", help="Ticker symbol or CIK of the company to analyze.")
+    parser.add_argument(
+        "--statement",
+        choices=["income", "balance"],
+        default="income",
+        help="Which statement to generate (default: income).",
+    )
+    parser.add_argument(
+        "--period",
+        choices=["annual", "quarterly"],
+        default="annual",
+        help="Which reporting period to use (default: annual).",
+    )
+    parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Force refresh of cached ticker metadata.",
+    )
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        ticker_info = sec_client.resolve_cik(args.ticker, force_refresh=args.force_refresh)
+        facts = sec_client.fetch_company_facts(ticker_info.cik)
+        builder = _statement_builder(args.statement)
+        lines = builder(facts, period=args.period)
+    except Exception as exc:  # pragma: no cover - CLI entry point
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Common size {args.statement} statement for {ticker_info.ticker} (CIK {ticker_info.cik})")
+    print(_render_table(lines))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/commonize/common_size.py
+++ b/commonize/common_size.py
@@ -1,0 +1,84 @@
+"""Utilities to build common size financial statements."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from . import sec_client
+
+
+@dataclass
+class CommonSizeLine:
+    label: str
+    value: Optional[float]
+    common_size: Optional[float]
+
+    def as_row(self) -> List[str]:
+        if self.value is None:
+            value_text = "-"
+        else:
+            value_text = f"{self.value:,.0f}"
+        if self.common_size is None:
+            percent_text = "-"
+        else:
+            percent_text = f"{self.common_size:.1%}"
+        return [self.label, value_text, percent_text]
+
+
+class StatementNotAvailableError(RuntimeError):
+    """Raised when the requested statement cannot be prepared."""
+
+
+def _build_lines(facts: dict, layout: Iterable[tuple], *, period: str) -> List[CommonSizeLine]:
+    lines: List[CommonSizeLine] = []
+    for label, tag in layout:
+        fact = sec_client.select_fact(facts, tag, period=period)
+        value = sec_client.extract_value(fact)
+        lines.append(CommonSizeLine(label=label, value=value, common_size=None))
+    return lines
+
+
+def _compute_common_size(lines: List[CommonSizeLine], *, denominator_index: int) -> None:
+    denominator = lines[denominator_index].value
+    if denominator in (0, None):
+        raise StatementNotAvailableError("Denominator for common size statement is missing or zero.")
+    for line in lines:
+        if line.value is None:
+            continue
+        line.common_size = line.value / denominator
+
+
+_INCOME_LAYOUT = [
+    ("Revenue", "Revenues"),
+    ("Cost of revenue", "CostOfRevenue"),
+    ("Gross profit", "GrossProfit"),
+    ("Research & development", "ResearchAndDevelopmentExpense"),
+    ("Selling, general & administrative", "SellingGeneralAndAdministrativeExpense"),
+    ("Operating income", "OperatingIncomeLoss"),
+    ("Net income", "NetIncomeLoss"),
+]
+
+_BALANCE_LAYOUT = [
+    ("Total assets", "Assets"),
+    ("Cash and cash equivalents", "CashAndCashEquivalentsAtCarryingValue"),
+    ("Accounts receivable", "AccountsReceivableNetCurrent"),
+    ("Inventory", "InventoryNet"),
+    ("Total liabilities", "Liabilities"),
+    ("Total equity", "StockholdersEquity"),
+]
+
+
+def build_income_statement(facts: dict, *, period: str = "annual") -> List[CommonSizeLine]:
+    lines = _build_lines(facts, _INCOME_LAYOUT, period=period)
+    if lines[0].value is None or lines[0].value == 0:
+        raise StatementNotAvailableError("Revenue not available for common size computation.")
+    _compute_common_size(lines, denominator_index=0)
+    return lines
+
+
+def build_balance_sheet(facts: dict, *, period: str = "annual") -> List[CommonSizeLine]:
+    lines = _build_lines(facts, _BALANCE_LAYOUT, period=period)
+    if lines[0].value is None or lines[0].value == 0:
+        raise StatementNotAvailableError("Total assets not available for common size computation.")
+    _compute_common_size(lines, denominator_index=0)
+    return lines

--- a/commonize/sec_client.py
+++ b/commonize/sec_client.py
@@ -1,0 +1,152 @@
+"""Utilities for communicating with the SEC data APIs."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+try:
+    import requests
+except ImportError:  # pragma: no cover - allows unit tests without requests
+    requests = None  # type: ignore
+
+_DEFAULT_USER_AGENT = os.environ.get(
+    "COMMONIZE_USER_AGENT",
+    "Commonize/0.1 (your_email@example.com)",
+)
+
+_TICKER_CACHE = Path(os.environ.get("COMMONIZE_CACHE", "./.commonize-cache"))
+_TICKER_CACHE.mkdir(parents=True, exist_ok=True)
+_TICKER_CACHE_FILE = _TICKER_CACHE / "ticker_cik_map.json"
+
+
+class SECClientError(RuntimeError):
+    """Raised when a request to the SEC API fails."""
+
+
+@dataclass
+class TickerInfo:
+    ticker: str
+    cik_str: str
+    title: str
+
+    @property
+    def cik(self) -> str:
+        return self.cik_str.zfill(10)
+
+
+def _request_json(url: str, *, sleep: float = 0.2) -> dict:
+    if requests is None:  # pragma: no cover - exercised when dependency missing
+        raise ImportError("The 'requests' package is required to call the SEC API.")
+    headers = {"User-Agent": _DEFAULT_USER_AGENT, "Accept-Encoding": "gzip, deflate"}
+    response = requests.get(url, headers=headers, timeout=30)
+    if response.status_code != 200:
+        raise SECClientError(f"SEC request failed with status {response.status_code}: {url}")
+    if sleep:
+        time.sleep(sleep)  # be kind to SEC infrastructure
+    return response.json()
+
+
+def _load_ticker_cache() -> Dict[str, TickerInfo]:
+    if not _TICKER_CACHE_FILE.exists():
+        return {}
+    with _TICKER_CACHE_FILE.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return {k: TickerInfo(**v) for k, v in data.items()}
+
+
+def _save_ticker_cache(data: Dict[str, TickerInfo]) -> None:
+    serializable = {k: v.__dict__ for k, v in data.items()}
+    with _TICKER_CACHE_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(serializable, fh)
+
+
+def fetch_ticker_map(force_refresh: bool = False) -> Dict[str, TickerInfo]:
+    """Return a mapping of ticker -> ticker information from the SEC."""
+    cache = _load_ticker_cache()
+    if cache and not force_refresh:
+        return cache
+
+    url = "https://www.sec.gov/files/company_tickers.json"
+    data = _request_json(url)
+    mapping: Dict[str, TickerInfo] = {}
+    for value in data.values():
+        ticker = value["ticker"].upper()
+        mapping[ticker] = TickerInfo(
+            ticker=ticker,
+            cik_str=str(value["cik_str"]),
+            title=value["title"],
+        )
+    _save_ticker_cache(mapping)
+    return mapping
+
+
+def resolve_cik(ticker_or_cik: str, *, force_refresh: bool = False) -> TickerInfo:
+    candidate = ticker_or_cik.strip().upper()
+    if candidate.isdigit() and len(candidate) <= 10:
+        return TickerInfo(ticker=candidate, cik_str=candidate, title="")
+
+    mapping = fetch_ticker_map(force_refresh=force_refresh)
+    if candidate not in mapping:
+        raise KeyError(f"Unknown ticker symbol '{candidate}'.")
+    return mapping[candidate]
+
+
+def fetch_company_facts(cik: str) -> dict:
+    info = resolve_cik(cik)
+    url = f"https://data.sec.gov/api/xbrl/companyfacts/CIK{info.cik}.json"
+    return _request_json(url, sleep=0.4)
+
+
+def _iter_facts_for_tag(facts: dict, tag: str) -> Iterable[dict]:
+    taxonomy = facts.get("facts", {}).get("us-gaap", {})
+    if tag not in taxonomy:
+        return []
+    tag_info = taxonomy[tag]
+    for units in tag_info.get("units", {}).values():
+        for item in units:
+            yield item
+
+
+def select_fact(
+    facts: dict,
+    tag: str,
+    *,
+    period: str = "annual",
+    forms: Optional[Iterable[str]] = None,
+) -> Optional[dict]:
+    """Select the most recent fact for ``tag`` matching ``period``."""
+    period = period.lower()
+    if forms is None:
+        forms = ("10-K",) if period == "annual" else ("10-Q", "10-K")
+
+    candidates = []
+    for item in _iter_facts_for_tag(facts, tag):
+        form = item.get("form")
+        if form not in forms:
+            continue
+        if period == "annual" and item.get("fp") not in {"FY", "Q4", "12M"}:
+            continue
+        if period == "quarterly" and item.get("fp") not in {"Q1", "Q2", "Q3", "Q4"}:
+            continue
+        end = item.get("end")
+        try:
+            end_date = datetime.fromisoformat(end)
+        except (TypeError, ValueError):
+            continue
+        candidates.append((end_date, item))
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    return candidates[0][1]
+
+
+def extract_value(fact: Optional[dict]) -> Optional[float]:
+    if not fact:
+        return None
+    return float(fact.get("val"))

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+"""Entry point for the commonize CLI."""
+from commonize import cli_main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(cli_main(None))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31
+python-tabulate>=0.9

--- a/tests/test_common_size.py
+++ b/tests/test_common_size.py
@@ -1,0 +1,58 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from commonize import common_size
+
+
+def _build_facts(tag_values):
+    return {
+        "facts": {
+            "us-gaap": {
+                tag: {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": value,
+                                "end": "2023-12-31",
+                                "form": form,
+                                "fp": fp,
+                            }
+                            for value, form, fp in values
+                        ]
+                    }
+                }
+                for tag, values in tag_values.items()
+            }
+        }
+    }
+
+
+def test_build_income_statement_computes_percentages():
+    facts = _build_facts(
+        {
+            "Revenues": [(100.0, "10-K", "FY")],
+            "CostOfRevenue": [(40.0, "10-K", "FY")],
+            "GrossProfit": [(60.0, "10-K", "FY")],
+            "ResearchAndDevelopmentExpense": [(10.0, "10-K", "FY")],
+            "SellingGeneralAndAdministrativeExpense": [(20.0, "10-K", "FY")],
+            "OperatingIncomeLoss": [(30.0, "10-K", "FY")],
+            "NetIncomeLoss": [(25.0, "10-K", "FY")],
+        }
+    )
+
+    lines = common_size.build_income_statement(facts)
+
+    assert lines[0].common_size == 1
+    assert lines[-1].common_size == 0.25
+
+
+def test_missing_denominator_raises():
+    facts = _build_facts({"Revenues": [(0.0, "10-K", "FY")]})
+    try:
+        common_size.build_income_statement(facts)
+    except common_size.StatementNotAvailableError:
+        pass
+    else:
+        raise AssertionError("Expected StatementNotAvailableError")


### PR DESCRIPTION
## Summary
- implement an SEC data client with cached ticker resolution and fact retrieval
- add common size statement builders, CLI entry point, and project documentation
- define project dependencies and unit tests covering statement normalization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68db455697408328a30987cd53e8be65