### PR TITLE
Ensure common-size statements align with SEC filings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,92 @@
+# Commonize
+
+Commonize turns U.S. Securities and Exchange Commission (SEC) filings into common size financial statements. The project ships
+with both a command line interface and a modern FastAPI web experience that renders statements, complete with CSV and Excel
+export options.
+
+## Features
+
+- Convert balance sheets or income statements into common size format
+- Retrieve data directly from the SEC's XBRL API
+- Cache ticker-to-CIK mappings locally for faster repeated use
+- Modern web UI for viewing statements and downloading CSV or Excel exports
+- Industry benchmarking that compares a company's common size results with peers sharing the same SEC SIC classification
+- Persistent local caching of computed industry averages to keep web requests responsive
+- Background job queue for precomputing industry benchmarks so that interactive requests stay low latency
+- Friendly command line interface with optional GitHub-flavored markdown output
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Set a descriptive user agent via the `COMMONIZE_USER_AGENT` environment variable to comply with SEC rate limiting guidance.
+
+```bash
+export COMMONIZE_USER_AGENT="CommonizeApp/0.1 (contact@example.com)"
+```
+
+## Usage
+
+```bash
+python main.py AAPL --statement income --period annual
+```
+
+Available options:
+
+- `ticker`: Ticker symbol or CIK
+- `--statement`: `income` or `balance`
+- `--period`: `annual` or `quarterly`
+- `--force-refresh`: Refreshes the cached ticker metadata
+- `--industry-peers`: Number of peer companies (matched by SEC standard industrial classification) to include when computing industry averages
+- `--queue-industry`: When the industry cache is cold, enqueue a background job instead of computing the benchmark inline
+
+### Running the web application
+
+```bash
+uvicorn commonize.web:create_app --factory --reload
+```
+
+Then open <http://127.0.0.1:8000> in your browser, enter a ticker symbol (for example, `AAPL`), and generate a statement. The
+interface renders the common size view, juxtaposes the company's metrics with industry averages derived from peer SEC filings, and exposes download buttons for CSV and Excel exports. When an industry benchmark is not yet cached the UI immediately renders the company statement and enqueues a background job so users are never blocked while SEC downloads complete.
+
+### Running the benchmark worker
+
+Industry benchmarks are computed by a lightweight worker to keep interactive requests fast. Launch the worker alongside the web app (or whenever you want to hydrate the cache):
+
+```bash
+python -m commonize.worker
+```
+
+If you prefer embedding the loop directly:
+
+```bash
+python - <<'PY'
+from commonize.industry_jobs import worker_loop
+import threading
+
+stop = threading.Event()
+try:
+    worker_loop(stop)
+except KeyboardInterrupt:
+    stop.set()
+PY
+```
+
+The CLI can enqueue background work via `--industry-peers ... --queue-industry` so the worker processes the benchmark.
+
+### Where the data comes from
+
+All company and industry data are sourced from the U.S. Securities and Exchange Commission (SEC) EDGAR program. Company facts and industry metadata are retrieved via the SEC's XBRL and submissions APIs, and peers are matched by the SEC-provided standard industrial classification (SIC) code before averaging their common size results.
+
+## Development roadmap
+
+1. **Local CLI** – Fetch SEC data and render common size statements in the terminal.
+2. **Interactive web experience (current stage)** – Serve the statements through FastAPI with downloadable exports.
+3. **Deployment** – Package and deploy the application to a managed cloud platform.
+4. **Automation & monitoring** – Expand the benchmark worker with scheduling, logging, and observability to ensure reliability.
+
+Contributions and ideas are welcome!

--- a/commonize/__init__.py
+++ b/commonize/__init__.py
@@ -1,0 +1,59 @@
+"""Commonize package for generating common size financial statements."""
+from typing import TYPE_CHECKING, Any
+
+from .common_size import (
+    CommonSizeLine,
+    StatementNotAvailableError,
+    build_balance_sheet,
+    build_income_statement,
+)
+from .cli import main as cli_main
+from .industry_cache import IndustryBenchmark, load_benchmark, store_benchmark
+from .sec_client import (
+    SECClientError,
+    IndustryInfo,
+    fetch_company_facts,
+    fetch_peer_company_facts,
+    fetch_ticker_map,
+    find_industry_peers,
+    get_company_industry,
+    resolve_cik,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - import for type hints only
+    from .web import create_app as _create_app
+    from .worker import main as _worker_main
+
+
+def create_app(*args: Any, **kwargs: Any):  # pragma: no cover - thin wrapper
+    from .web import create_app as _create_app
+
+    return _create_app(*args, **kwargs)
+
+
+def worker_main(*args: Any, **kwargs: Any) -> None:  # pragma: no cover - thin wrapper
+    from .worker import main as _worker_main
+
+    _worker_main(*args, **kwargs)
+
+
+__all__ = [
+    "CommonSizeLine",
+    "StatementNotAvailableError",
+    "SECClientError",
+    "build_balance_sheet",
+    "build_income_statement",
+    "cli_main",
+    "create_app",
+    "worker_main",
+    "IndustryBenchmark",
+    "load_benchmark",
+    "store_benchmark",
+    "fetch_company_facts",
+    "fetch_peer_company_facts",
+    "fetch_ticker_map",
+    "find_industry_peers",
+    "get_company_industry",
+    "IndustryInfo",
+    "resolve_cik",
+]

--- a/commonize/cli.py
+++ b/commonize/cli.py
@@ -1,0 +1,141 @@
+"""Command line interface for generating common size statements."""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Callable, Iterable, List
+
+from . import common_size, industry_cache, industry_jobs, sec_client
+
+try:
+    from tabulate import tabulate
+except ImportError:  # pragma: no cover - fallback when tabulate not installed
+    tabulate = None  # type: ignore
+
+
+def _statement_builder(name: str) -> Callable[[dict, str], List[common_size.CommonSizeLine]]:
+    if name == "income":
+        return common_size.build_income_statement
+    if name == "balance":
+        return common_size.build_balance_sheet
+    raise ValueError(f"Unsupported statement type '{name}'.")
+
+
+def _render_table(lines: Iterable[common_size.CommonSizeLine]) -> str:
+    rows = [line.as_row() for line in lines]
+    headers = [
+        "Line item",
+        "Value (USD millions)",
+        "Company common size",
+        "Industry common size",
+    ]
+    if tabulate:
+        return tabulate(rows, headers=headers, tablefmt="github")
+    # Simple fallback rendering
+    column_widths = [max(len(str(row[i])) for row in rows + [headers]) for i in range(len(headers))]
+    lines_out = [
+        " | ".join(h.ljust(column_widths[idx]) for idx, h in enumerate(headers)),
+        "-+-".join("-" * column_widths[idx] for idx in range(len(headers))),
+    ]
+    for row in rows:
+        lines_out.append(
+            " | ".join(str(cell).ljust(column_widths[idx]) for idx, cell in enumerate(row))
+        )
+    return "\n".join(lines_out)
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate common size financial statements from SEC data.")
+    parser.add_argument("ticker", help="Ticker symbol or CIK of the company to analyze.")
+    parser.add_argument(
+        "--statement",
+        choices=["income", "balance"],
+        default="income",
+        help="Which statement to generate (default: income).",
+    )
+    parser.add_argument(
+        "--period",
+        choices=["annual", "quarterly"],
+        default="annual",
+        help="Which reporting period to use (default: annual).",
+    )
+    parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Force refresh of cached ticker metadata.",
+    )
+    parser.add_argument(
+        "--industry-peers",
+        type=int,
+        default=0,
+        help="Number of peer companies (same SIC) to include when computing industry averages.",
+    )
+    parser.add_argument(
+        "--queue-industry",
+        action="store_true",
+        help=(
+            "Queue a background job to build the industry benchmark when the cache is cold"
+            " instead of fetching peer filings inline."
+        ),
+    )
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        ticker_info = sec_client.resolve_cik(args.ticker, force_refresh=args.force_refresh)
+        facts = sec_client.fetch_company_facts(ticker_info.cik)
+        industry_info = sec_client.get_company_industry(ticker_info.cik)
+        builder = _statement_builder(args.statement)
+        lines = builder(facts, period=args.period)
+
+        if args.industry_peers > 0:
+            benchmark = industry_cache.load_benchmark(
+                industry_info.sic,
+                args.statement,
+                args.period,
+                expected_line_count=len(lines),
+            )
+            if benchmark:
+                for idx, ratio in enumerate(benchmark.ratios):
+                    if idx < len(lines) and ratio is not None:
+                        lines[idx].industry_common_size = ratio
+            else:
+                if args.queue_industry:
+                    industry_jobs.ensure_benchmark_ready(
+                        ticker_info,
+                        industry_info,
+                        args.statement,
+                        args.period,
+                        max_companies=args.industry_peers,
+                    )
+                else:
+                    _, peers, peer_fact_list = sec_client.fetch_peer_company_facts(
+                        ticker_info.cik, max_companies=args.industry_peers
+                    )
+                    if peer_fact_list:
+                        lines = builder(facts, period=args.period, peers=peer_fact_list)
+                        ratios = [line.industry_common_size for line in lines]
+                        try:
+                            industry_cache.store_benchmark(
+                                industry_info.sic,
+                                args.statement,
+                                args.period,
+                                ratios,
+                                len(peers),
+                                line_count=len(lines),
+                            )
+                        except ValueError:
+                            pass
+    except Exception as exc:  # pragma: no cover - CLI entry point
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Common size {args.statement} statement for {ticker_info.ticker} (CIK {ticker_info.cik})")
+    print(_render_table(lines))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/commonize/common_size.py
+++ b/commonize/common_size.py
@@ -1,0 +1,472 @@
+"""Utilities to build common size financial statements."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Optional, Sequence, Tuple, Union
+
+from . import sec_client
+
+
+@dataclass
+class CommonSizeLine:
+    label: str
+    value: Optional[float]
+    common_size: Optional[float]
+    indent: int = 0
+    is_header: bool = False
+    industry_common_size: Optional[float] = None
+
+    def value_in_millions(self) -> Optional[float]:
+        if self.value is None:
+            return None
+        return self.value / 1_000_000
+
+    def as_row(self) -> List[str]:
+        value_millions = self.value_in_millions()
+        if value_millions is None:
+            value_text = "-"
+        else:
+            value_text = f"{value_millions:,.1f}"
+        if self.common_size is None:
+            percent_text = "-"
+        else:
+            percent_text = f"{self.common_size:.1%}"
+        if self.industry_common_size is None:
+            industry_text = "-"
+        else:
+            industry_text = f"{self.industry_common_size:.1%}"
+        return [self.label, value_text, percent_text, industry_text]
+
+
+class StatementNotAvailableError(RuntimeError):
+    """Raised when the requested statement cannot be prepared."""
+
+
+TagSpec = Optional[Union[str, Sequence[str]]]
+
+
+def _normalize_tag_spec(tag: TagSpec) -> Tuple[str, ...]:
+    if tag is None:
+        return tuple()
+    if isinstance(tag, str):
+        return (tag,)
+    return tuple(tag)
+
+
+def _build_lines(
+    facts: dict,
+    layout: Iterable[tuple],
+    *,
+    period: str,
+    denominator_index: int,
+) -> List[CommonSizeLine]:
+    layout_list = list(layout)
+    lines: List[CommonSizeLine] = []
+    selected: dict[int, Tuple[Optional[dict], Optional[float]]] = {}
+
+    reference_fact: Optional[dict] = None
+    if 0 <= denominator_index < len(layout_list):
+        denom_item = layout_list[denominator_index]
+        denom_tag = denom_item[1] if len(denom_item) >= 2 else None
+        for candidate_tag in _normalize_tag_spec(denom_tag):
+            fact = sec_client.select_fact(facts, candidate_tag, period=period)
+            value = sec_client.extract_value(fact)
+            if value is not None:
+                reference_fact = fact
+                selected[denominator_index] = (fact, value)
+                break
+
+    for index, item in enumerate(layout_list):
+        if len(item) == 2:
+            label, tag = item
+            indent = 0
+            is_header = tag is None
+        elif len(item) == 3:
+            label, tag, indent = item
+            is_header = tag is None
+        elif len(item) == 4:
+            label, tag, indent, is_header = item
+        else:  # pragma: no cover - defensive guard
+            raise ValueError("Layout entries must have 2 to 4 elements")
+
+        fact: Optional[dict] = None
+        value: Optional[float] = None
+        if is_header or tag is None:
+            value = None
+        elif index in selected:
+            fact, value = selected[index]
+        else:
+            for candidate_tag in _normalize_tag_spec(tag):
+                fact = sec_client.select_fact(
+                    facts,
+                    candidate_tag,
+                    period=period,
+                    reference=reference_fact,
+                )
+                value = sec_client.extract_value(fact)
+                if value is not None:
+                    break
+
+        lines.append(
+            CommonSizeLine(
+                label=label,
+                value=value,
+                common_size=None,
+                indent=indent,
+                is_header=is_header,
+            )
+        )
+    return lines
+
+
+def _compute_common_size(lines: List[CommonSizeLine], *, denominator_index: int) -> None:
+    denominator = lines[denominator_index].value
+    if denominator in (0, None):
+        raise StatementNotAvailableError("Denominator for common size statement is missing or zero.")
+    for line in lines:
+        if line.value is None:
+            continue
+        line.common_size = line.value / denominator
+
+
+def _apply_industry_average(
+    lines: List[CommonSizeLine],
+    peer_facts: Iterable[dict],
+    *,
+    layout: Iterable[tuple],
+    denominator_index: int,
+    period: str,
+    derive_fn: Optional[Callable[[List[CommonSizeLine]], None]] = None,
+) -> None:
+    peer_ratios: List[List[Optional[float]]] = []
+    for facts in peer_facts:
+        peer_lines = _build_lines(
+            facts,
+            layout,
+            period=period,
+            denominator_index=denominator_index,
+        )
+        if derive_fn is not None:
+            derive_fn(peer_lines)
+        try:
+            _compute_common_size(peer_lines, denominator_index=denominator_index)
+        except StatementNotAvailableError:
+            continue
+        peer_ratios.append([line.common_size for line in peer_lines])
+
+    if not peer_ratios:
+        return
+
+    for index, line in enumerate(lines):
+        values = [row[index] for row in peer_ratios if row[index] is not None]
+        if not values:
+            continue
+        line.industry_common_size = sum(values) / len(values)
+
+
+def _apply_income_derivations(lines: List[CommonSizeLine]) -> None:
+    lookup = {line.label: line for line in lines}
+
+    revenue = lookup.get("Revenue")
+    cost = lookup.get("Cost of revenue")
+    gross = lookup.get("Gross profit")
+    if revenue and gross and revenue.value is not None and gross.value is not None:
+        derived_cost = revenue.value - gross.value
+        if cost and (cost.value is None or abs((cost.value or 0) - derived_cost) > 1.0):
+            cost.value = derived_cost
+    elif revenue and cost and revenue.value is not None and cost.value is not None:
+        derived_gross = revenue.value - cost.value
+        if gross and (gross.value is None or abs((gross.value or 0) - derived_gross) > 1.0):
+            gross.value = derived_gross
+
+    cost = lookup.get("Cost of revenue")
+    gross = lookup.get("Gross profit")
+    revenue = lookup.get("Revenue")
+    rd = lookup.get("Research & development")
+    sgna = lookup.get("Selling, general & administrative")
+    other_ops = lookup.get("Other operating expenses")
+    total_ops = lookup.get("Total operating expenses")
+    op_income = lookup.get("Operating income")
+    interest = lookup.get("Interest expense")
+    other_income = lookup.get("Other income (expense)")
+    pretax = lookup.get("Income before taxes")
+    tax = lookup.get("Income tax expense (benefit)")
+    net_income = lookup.get("Net income")
+
+    component_values = [
+        line.value for line in (rd, sgna, other_ops) if line and line.value is not None
+    ]
+    if total_ops and component_values:
+        derived_total = sum(component_values)
+        if total_ops.value is None or abs(total_ops.value - derived_total) > 1.0:
+            total_ops.value = derived_total
+
+    if gross and total_ops and gross.value is not None and total_ops.value is not None:
+        derived_operating = gross.value - total_ops.value
+        if op_income and (op_income.value is None or abs(op_income.value - derived_operating) > 1.0):
+            op_income.value = derived_operating
+
+    if op_income and other_income and op_income.value is not None and other_income.value is not None:
+        derived_pretax = op_income.value + other_income.value
+        if interest and interest.value is not None:
+            derived_pretax -= interest.value
+        if pretax and (pretax.value is None or abs(pretax.value - derived_pretax) > 1.0):
+            pretax.value = derived_pretax
+
+    if pretax and tax and pretax.value is not None and tax.value is not None:
+        derived_net = pretax.value - tax.value
+        if net_income and (net_income.value is None or abs(net_income.value - derived_net) > 1.0):
+            net_income.value = derived_net
+
+    if revenue and cost and gross and revenue.value is not None and cost.value is not None:
+        derived_gross = revenue.value - cost.value
+        if gross.value is None or abs(gross.value - derived_gross) > 1.0:
+            gross.value = derived_gross
+
+
+def _apply_balance_derivations(lines: List[CommonSizeLine]) -> None:
+    lookup = {line.label: line for line in lines}
+    total_assets = lookup.get("Total assets")
+    total_liabilities = lookup.get("Total liabilities")
+    total_equity = lookup.get("Total stockholders' equity")
+    total_liab_equity = lookup.get("Total liabilities and equity")
+
+    if total_liabilities and total_equity:
+        if total_liabilities.value is not None and total_equity.value is not None:
+            derived_total = total_liabilities.value + total_equity.value
+            if total_liab_equity and (
+                total_liab_equity.value is None
+                or abs(total_liab_equity.value - derived_total) > 1.0
+            ):
+                total_liab_equity.value = derived_total
+
+    if total_assets and total_assets.value is not None and total_liab_equity:
+        if total_liab_equity.value is None:
+            total_liab_equity.value = total_assets.value
+
+
+_INCOME_LAYOUT = [
+    (
+        "Revenue",
+        (
+            "Revenues",
+            "RevenueFromContractWithCustomerExcludingAssessedTax",
+            "SalesRevenueNet",
+            "SalesRevenueGoodsNet",
+        ),
+        0,
+    ),
+    (
+        "Cost of revenue",
+        (
+            "CostOfRevenue",
+            "CostOfGoodsAndServicesSold",
+            "CostOfSales",
+            "CostOfGoodsSold",
+        ),
+        1,
+    ),
+    ("Gross profit", ("GrossProfit", "GrossProfitLoss"), 0),
+    ("Operating expenses", None, 0, True),
+    (
+        "Research & development",
+        ("ResearchAndDevelopmentExpense", "ResearchAndDevelopment"),
+        1,
+    ),
+    (
+        "Selling, general & administrative",
+        ("SellingGeneralAndAdministrativeExpense", "SellingGeneralAndAdministrativeExpenses"),
+        1,
+    ),
+    (
+        "Other operating expenses",
+        ("OtherOperatingExpenses", "OtherOperatingIncomeExpense"),
+        1,
+    ),
+    ("Total operating expenses", ("OperatingExpenses", "OperatingCostsAndExpenses"), 0),
+    ("Operating income", ("OperatingIncomeLoss", "OperatingProfitLoss"), 0),
+    ("Interest expense", ("InterestExpense", "InterestExpenseDebt"), 1),
+    (
+        "Other income (expense)",
+        ("OtherNonoperatingIncomeExpense", "NonoperatingIncomeExpense"),
+        1,
+    ),
+    (
+        "Income before taxes",
+        (
+            "IncomeLossFromContinuingOperationsBeforeIncomeTaxes",
+            "IncomeBeforeIncomeTaxes",
+        ),
+        0,
+    ),
+    (
+        "Income tax expense (benefit)",
+        ("IncomeTaxExpenseBenefit", "IncomeTaxExpenseBenefitContinuingOperations"),
+        1,
+    ),
+    ("Net income", ("NetIncomeLoss", "ProfitLoss"), 0),
+]
+
+_BALANCE_LAYOUT = [
+    ("Total assets", "Assets", 0),
+    ("Current assets", None, 0, True),
+    (
+        "Cash and cash equivalents",
+        ("CashAndCashEquivalentsAtCarryingValue", "CashCashEquivalentsAndShortTermInvestments"),
+        1,
+    ),
+    (
+        "Short-term investments",
+        ("MarketableSecuritiesCurrent", "AvailableForSaleSecuritiesCurrent"),
+        1,
+    ),
+    (
+        "Accounts receivable",
+        ("AccountsReceivableNetCurrent", "AccountsReceivableTradeNetCurrent"),
+        1,
+    ),
+    ("Inventory", ("InventoryNet", "InventoryFinishedGoods"), 1),
+    ("Other current assets", ("OtherAssetsCurrent", "PrepaidExpenseAndOtherAssetsCurrent"), 1),
+    ("Total current assets", ("AssetsCurrent", "CurrentAssets"), 0),
+    ("Non-current assets", None, 0, True),
+    (
+        "Property, plant and equipment, net",
+        ("PropertyPlantAndEquipmentNet", "PropertyPlantAndEquipmentIncludingConstructionInProgress"),
+        1,
+    ),
+    (
+        "Operating lease right-of-use assets",
+        ("OperatingLeaseRightOfUseAsset", "OperatingLeaseRightOfUseAssetNoncurrent"),
+        1,
+    ),
+    ("Goodwill", "Goodwill", 1),
+    (
+        "Intangible assets, net",
+        ("IntangibleAssetsNetExcludingGoodwill", "IntangibleAssetsNet"),
+        1,
+    ),
+    ("Other non-current assets", ("OtherAssetsNoncurrent", "OtherAssets"), 1),
+    ("Total non-current assets", ("AssetsNoncurrent", "NoncurrentAssets"), 0),
+    ("Liabilities and equity", None, 0, True),
+    ("Current liabilities", None, 0, True),
+    (
+        "Accounts payable",
+        ("AccountsPayableCurrent", "AccountsPayableTradeCurrent"),
+        1,
+    ),
+    (
+        "Accrued liabilities",
+        ("AccruedLiabilitiesCurrent", "AccruedExpensesAndOtherCurrentLiabilities"),
+        1,
+    ),
+    (
+        "Short-term debt",
+        ("ShortTermBorrowings", "ShortTermDebtAndCurrentPortionOfLongTermDebt"),
+        1,
+    ),
+    ("Other current liabilities", ("OtherLiabilitiesCurrent", "OtherLiabilities"), 1),
+    ("Total current liabilities", ("LiabilitiesCurrent", "CurrentLiabilities"), 0),
+    ("Non-current liabilities", None, 0, True),
+    (
+        "Long-term debt",
+        ("LongTermDebtNoncurrent", "LongTermDebtAndCapitalLeaseObligations"),
+        1,
+    ),
+    (
+        "Operating lease liabilities",
+        (
+            "OperatingLeaseLiabilityNoncurrent",
+            "OperatingLeaseLiability",
+        ),
+        1,
+    ),
+    ("Other non-current liabilities", ("OtherLiabilitiesNoncurrent", "OtherNoncurrentLiabilities"), 1),
+    ("Total non-current liabilities", ("LiabilitiesNoncurrent", "NoncurrentLiabilities"), 0),
+    ("Total liabilities", ("Liabilities", "LiabilitiesAndStockholdersEquityAttributableToParent"), 0),
+    ("Stockholders' equity", None, 0, True),
+    ("Common stock", ("CommonStockValue", "CommonStockCapital"), 1),
+    ("Additional paid-in capital", ("AdditionalPaidInCapital", "AdditionalPaidInCapitalCommonStock"), 1),
+    (
+        "Retained earnings",
+        ("RetainedEarningsAccumulatedDeficit", "RetainedEarnings"),
+        1,
+    ),
+    (
+        "Accumulated other comprehensive income (loss)",
+        (
+            "AccumulatedOtherComprehensiveIncomeLossNetOfTax",
+            "AccumulatedOtherComprehensiveIncomeLoss",
+        ),
+        1,
+    ),
+    ("Treasury stock", ("TreasuryStockValue", "TreasuryStockCommon"), 1),
+    (
+        "Total stockholders' equity",
+        (
+            "StockholdersEquity",
+            "StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest",
+        ),
+        0,
+    ),
+    (
+        "Total liabilities and equity",
+        ("LiabilitiesAndStockholdersEquity", "LiabilitiesAndShareholdersEquity"),
+        0,
+    ),
+]
+
+
+def build_income_statement(
+    facts: dict,
+    *,
+    period: str = "annual",
+    peers: Optional[Iterable[dict]] = None,
+) -> List[CommonSizeLine]:
+    lines = _build_lines(
+        facts,
+        _INCOME_LAYOUT,
+        period=period,
+        denominator_index=0,
+    )
+    _apply_income_derivations(lines)
+    if lines[0].value is None or lines[0].value == 0:
+        raise StatementNotAvailableError("Revenue not available for common size computation.")
+    _compute_common_size(lines, denominator_index=0)
+    if peers:
+        _apply_industry_average(
+            lines,
+            peers,
+            layout=_INCOME_LAYOUT,
+            denominator_index=0,
+            period=period,
+            derive_fn=_apply_income_derivations,
+        )
+    return lines
+
+
+def build_balance_sheet(
+    facts: dict,
+    *,
+    period: str = "annual",
+    peers: Optional[Iterable[dict]] = None,
+) -> List[CommonSizeLine]:
+    lines = _build_lines(
+        facts,
+        _BALANCE_LAYOUT,
+        period=period,
+        denominator_index=0,
+    )
+    _apply_balance_derivations(lines)
+    if lines[0].value is None or lines[0].value == 0:
+        raise StatementNotAvailableError("Total assets not available for common size computation.")
+    _compute_common_size(lines, denominator_index=0)
+    if peers:
+        _apply_industry_average(
+            lines,
+            peers,
+            layout=_BALANCE_LAYOUT,
+            denominator_index=0,
+            period=period,
+            derive_fn=_apply_balance_derivations,
+        )
+    return lines

--- a/commonize/industry_cache.py
+++ b/commonize/industry_cache.py
@@ -1,0 +1,144 @@
+"""Caching helpers for industry benchmark data."""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+_CACHE_DIR = Path(os.environ.get("COMMONIZE_CACHE", "./.commonize-cache"))
+_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+_DB_PATH = _CACHE_DIR / "industry_benchmarks.sqlite3"
+
+# Expose the database path so other modules (such as background workers) can
+# coordinate on the same persistent store without duplicating configuration.
+DB_PATH = _DB_PATH
+
+_DEFAULT_TTL_SECONDS = int(os.environ.get("COMMONIZE_INDUSTRY_CACHE_TTL", 60 * 60 * 24 * 7))
+
+
+@dataclass
+class IndustryBenchmark:
+    """Representation of cached industry benchmark ratios."""
+
+    ratios: List[Optional[float]]
+    peer_count: int
+    line_count: int
+    updated_at: float
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS industry_benchmarks (
+            sic TEXT NOT NULL,
+            statement TEXT NOT NULL,
+            period TEXT NOT NULL,
+            ratios TEXT NOT NULL,
+            peer_count INTEGER NOT NULL,
+            line_count INTEGER NOT NULL,
+            updated_at REAL NOT NULL,
+            PRIMARY KEY (sic, statement, period)
+        )
+        """
+    )
+
+
+def ensure_cache_schema(conn: sqlite3.Connection) -> None:
+    """Public wrapper so other modules can ensure the cache table exists."""
+
+    _ensure_schema(conn)
+
+
+def load_benchmark(
+    sic: Optional[str],
+    statement: str,
+    period: str,
+    *,
+    expected_line_count: Optional[int] = None,
+    max_age_seconds: Optional[int] = None,
+) -> Optional[IndustryBenchmark]:
+    """Return a cached benchmark for ``sic`` if it is still valid."""
+
+    if not sic:
+        return None
+    if max_age_seconds is None:
+        max_age_seconds = _DEFAULT_TTL_SECONDS
+
+    with sqlite3.connect(_DB_PATH) as conn:
+        _ensure_schema(conn)
+        row = conn.execute(
+            """
+            SELECT ratios, peer_count, line_count, updated_at
+            FROM industry_benchmarks
+            WHERE sic = ? AND statement = ? AND period = ?
+            """,
+            (sic, statement, period),
+        ).fetchone()
+
+    if not row:
+        return None
+
+    ratios_json, peer_count, line_count, updated_at = row
+    if expected_line_count is not None and line_count != expected_line_count:
+        return None
+    if max_age_seconds and max_age_seconds > 0:
+        if time.time() - updated_at > max_age_seconds:
+            return None
+
+    ratios = json.loads(ratios_json)
+    # Ensure ratios length matches expected when provided
+    if expected_line_count is not None and len(ratios) != expected_line_count:
+        return None
+
+    return IndustryBenchmark(
+        ratios=list(ratios),
+        peer_count=int(peer_count),
+        line_count=int(line_count),
+        updated_at=float(updated_at),
+    )
+
+
+def store_benchmark(
+    sic: Optional[str],
+    statement: str,
+    period: str,
+    ratios: Iterable[Optional[float]],
+    peer_count: int,
+    *,
+    line_count: int,
+) -> None:
+    """Persist ``ratios`` for the given industry if possible."""
+
+    if not sic:
+        return
+
+    ratios_list = list(ratios)
+    if not ratios_list:
+        return
+    if len(ratios_list) != line_count:
+        raise ValueError("Line count mismatch when storing industry benchmark")
+
+    timestamp = time.time()
+    payload = json.dumps(ratios_list)
+
+    with sqlite3.connect(_DB_PATH) as conn:
+        _ensure_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO industry_benchmarks (
+                sic, statement, period, ratios, peer_count, line_count, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(sic, statement, period)
+            DO UPDATE SET
+                ratios = excluded.ratios,
+                peer_count = excluded.peer_count,
+                line_count = excluded.line_count,
+                updated_at = excluded.updated_at
+            """,
+            (sic, statement, period, payload, int(peer_count), int(line_count), timestamp),
+        )
+        conn.commit()

--- a/commonize/industry_jobs.py
+++ b/commonize/industry_jobs.py
@@ -1,0 +1,308 @@
+"""Background job orchestration for computing industry benchmarks."""
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+from .common_size import (
+    CommonSizeLine,
+    StatementNotAvailableError,
+    build_balance_sheet,
+    build_income_statement,
+)
+from .industry_cache import DB_PATH, ensure_cache_schema, load_benchmark, store_benchmark
+from .sec_client import (
+    SECClientError,
+    IndustryInfo,
+    TickerInfo,
+    fetch_company_facts,
+    fetch_peer_company_facts,
+)
+
+
+_JOB_STATEMENTS: Dict[str, Callable[..., list[CommonSizeLine]]] = {
+    "income": build_income_statement,
+    "balance": build_balance_sheet,
+}
+
+
+@dataclass
+class BenchmarkJob:
+    """Representation of a queued benchmark computation."""
+
+    sic: Optional[str]
+    statement: str
+    period: str
+    max_companies: int
+    subject_cik: str
+    subject_ticker: str
+    subject_title: str
+    status: str
+    queued_at: float
+    started_at: Optional[float]
+    finished_at: Optional[float]
+    attempts: int
+    error: Optional[str]
+
+
+def _ensure_job_schema(conn: sqlite3.Connection) -> None:
+    ensure_cache_schema(conn)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS benchmark_jobs (
+            sic TEXT,
+            statement TEXT NOT NULL,
+            period TEXT NOT NULL,
+            max_companies INTEGER NOT NULL,
+            subject_cik TEXT NOT NULL,
+            subject_ticker TEXT NOT NULL,
+            subject_title TEXT NOT NULL,
+            status TEXT NOT NULL,
+            queued_at REAL NOT NULL,
+            started_at REAL,
+            finished_at REAL,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            error TEXT,
+            PRIMARY KEY (sic, statement, period)
+        )
+        """
+    )
+
+
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    _ensure_job_schema(conn)
+    return conn
+
+
+def enqueue_benchmark_job(
+    subject: TickerInfo,
+    industry: IndustryInfo,
+    statement: str,
+    period: str,
+    *,
+    max_companies: int,
+    force: bool = False,
+) -> None:
+    """Persist a benchmark job if one is not already queued."""
+
+    if not industry.sic:
+        return
+
+    now = time.time()
+    payload = (
+        industry.sic,
+        statement,
+        period,
+        int(max_companies),
+        subject.cik,
+        subject.ticker,
+        subject.title,
+    )
+
+    with _connect() as conn:
+        row = conn.execute(
+            """
+            SELECT status FROM benchmark_jobs
+            WHERE sic = ? AND statement = ? AND period = ?
+            """,
+            (industry.sic, statement, period),
+        ).fetchone()
+
+        if row:
+            if force and row[0] != "running":
+                conn.execute(
+                    """
+                    UPDATE benchmark_jobs
+                    SET status = 'pending', queued_at = ?, started_at = NULL,
+                        finished_at = NULL, attempts = 0, error = NULL,
+                        max_companies = ?, subject_cik = ?,
+                        subject_ticker = ?, subject_title = ?
+                    WHERE sic = ? AND statement = ? AND period = ?
+                    """,
+                    (
+                        now,
+                        int(max_companies),
+                        subject.cik,
+                        subject.ticker,
+                        subject.title,
+                        industry.sic,
+                        statement,
+                        period,
+                    ),
+                )
+                conn.commit()
+            return
+
+        conn.execute(
+            """
+            INSERT INTO benchmark_jobs (
+                sic, statement, period, max_companies,
+                subject_cik, subject_ticker, subject_title,
+                status, queued_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+            """,
+            payload + (now,),
+        )
+        conn.commit()
+
+
+def get_job_status(sic: Optional[str], statement: str, period: str) -> Optional[BenchmarkJob]:
+    if not sic:
+        return None
+    with _connect() as conn:
+        row = conn.execute(
+            """
+            SELECT sic, statement, period, max_companies, subject_cik,
+                   subject_ticker, subject_title, status, queued_at,
+                   started_at, finished_at, attempts, error
+            FROM benchmark_jobs
+            WHERE sic = ? AND statement = ? AND period = ?
+            """,
+            (sic, statement, period),
+        ).fetchone()
+    if not row:
+        return None
+    return BenchmarkJob(*row)
+
+
+def _row_to_job(row: tuple) -> BenchmarkJob:
+    return BenchmarkJob(*row)
+
+
+def claim_next_job() -> Optional[BenchmarkJob]:
+    with _connect() as conn:
+        conn.isolation_level = None
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            """
+            SELECT sic, statement, period, max_companies, subject_cik,
+                   subject_ticker, subject_title, status, queued_at,
+                   started_at, finished_at, attempts, error
+            FROM benchmark_jobs
+            WHERE status = 'pending'
+            ORDER BY queued_at ASC
+            LIMIT 1
+            """,
+        ).fetchone()
+        if not row:
+            conn.execute("COMMIT")
+            return None
+
+        job = _row_to_job(row)
+        conn.execute(
+            """
+            UPDATE benchmark_jobs
+            SET status = 'running', started_at = ?, attempts = attempts + 1
+            WHERE sic = ? AND statement = ? AND period = ?
+            """,
+            (time.time(), job.sic, job.statement, job.period),
+        )
+        conn.execute("COMMIT")
+        job.status = "running"
+    return job
+
+
+def _complete_job(job: BenchmarkJob, status: str, error: Optional[str] = None) -> None:
+    with _connect() as conn:
+        conn.execute(
+            """
+            UPDATE benchmark_jobs
+            SET status = ?, finished_at = ?, error = ?
+            WHERE sic = ? AND statement = ? AND period = ?
+            """,
+            (status, time.time(), error, job.sic, job.statement, job.period),
+        )
+        conn.commit()
+
+
+def process_job(job: BenchmarkJob) -> None:
+    builder = _JOB_STATEMENTS.get(job.statement)
+    if builder is None:
+        _complete_job(job, "failed", f"Unknown statement '{job.statement}'")
+        return
+
+    try:
+        facts = fetch_company_facts(job.subject_cik)
+        industry_info, peers, peer_facts = fetch_peer_company_facts(
+            job.subject_cik, max_companies=job.max_companies
+        )
+    except (SECClientError, KeyError) as exc:
+        _complete_job(job, "failed", str(exc))
+        return
+
+    if not peer_facts:
+        _complete_job(job, "failed", "No peer filings available")
+        return
+
+    try:
+        lines = builder(facts, period=job.period, peers=peer_facts)
+    except StatementNotAvailableError as exc:
+        _complete_job(job, "failed", str(exc))
+        return
+
+    ratios = [line.industry_common_size for line in lines]
+    try:
+        store_benchmark(
+            industry_info.sic,
+            job.statement,
+            job.period,
+            ratios,
+            len(peers),
+            line_count=len(lines),
+        )
+    except ValueError as exc:
+        _complete_job(job, "failed", str(exc))
+        return
+
+    _complete_job(job, "succeeded", None)
+
+
+def worker_loop(stop_event: threading.Event, poll_interval: float = 2.0) -> None:
+    """Run a worker loop until ``stop_event`` is set."""
+
+    while not stop_event.is_set():
+        job = claim_next_job()
+        if job is None:
+            stop_event.wait(poll_interval)
+            continue
+        process_job(job)
+
+
+def ensure_benchmark_ready(
+    subject: TickerInfo,
+    industry: IndustryInfo,
+    statement: str,
+    period: str,
+    *,
+    max_companies: int,
+) -> Optional[BenchmarkJob]:
+    """Ensure a benchmark exists, queueing work when missing."""
+
+    benchmark = load_benchmark(industry.sic, statement, period)
+    if benchmark is not None:
+        return None
+
+    enqueue_benchmark_job(
+        subject,
+        industry,
+        statement,
+        period,
+        max_companies=max_companies,
+    )
+    return get_job_status(industry.sic, statement, period)
+
+
+__all__ = [
+    "BenchmarkJob",
+    "enqueue_benchmark_job",
+    "get_job_status",
+    "claim_next_job",
+    "process_job",
+    "worker_loop",
+    "ensure_benchmark_ready",
+]
+

--- a/commonize/sec_client.py
+++ b/commonize/sec_client.py
@@ -1,0 +1,322 @@
+"""Utilities for communicating with the SEC data APIs."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+try:
+    import requests
+except ImportError:  # pragma: no cover - allows unit tests without requests
+    requests = None  # type: ignore
+
+_DEFAULT_USER_AGENT = os.environ.get(
+    "COMMONIZE_USER_AGENT",
+    "Commonize/0.1 (your_email@example.com)",
+)
+
+_TICKER_CACHE = Path(os.environ.get("COMMONIZE_CACHE", "./.commonize-cache"))
+_TICKER_CACHE.mkdir(parents=True, exist_ok=True)
+_TICKER_CACHE_FILE = _TICKER_CACHE / "ticker_cik_map.json"
+_SIC_CACHE_FILE = _TICKER_CACHE / "cik_sic_map.json"
+
+
+class SECClientError(RuntimeError):
+    """Raised when a request to the SEC API fails."""
+
+
+@dataclass
+class TickerInfo:
+    ticker: str
+    cik_str: str
+    title: str
+
+    @property
+    def cik(self) -> str:
+        return self.cik_str.zfill(10)
+
+
+@dataclass
+class IndustryInfo:
+    sic: Optional[str]
+    description: Optional[str]
+
+
+_sic_cache: Optional[Dict[str, Dict[str, Optional[str]]]] = None
+
+
+def _load_sic_cache() -> Dict[str, Dict[str, Optional[str]]]:
+    global _sic_cache
+    if _sic_cache is not None:
+        return _sic_cache
+    if not _SIC_CACHE_FILE.exists():
+        _sic_cache = {}
+        return _sic_cache
+    with _SIC_CACHE_FILE.open("r", encoding="utf-8") as fh:
+        _sic_cache = json.load(fh)
+    return _sic_cache
+
+
+def _save_sic_cache(data: Dict[str, Dict[str, Optional[str]]]) -> None:
+    global _sic_cache
+    _sic_cache = data
+    with _SIC_CACHE_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+
+
+def _request_json(url: str, *, sleep: float = 0.2) -> dict:
+    if requests is None:  # pragma: no cover - exercised when dependency missing
+        raise ImportError("The 'requests' package is required to call the SEC API.")
+    headers = {"User-Agent": _DEFAULT_USER_AGENT, "Accept-Encoding": "gzip, deflate"}
+    response = requests.get(url, headers=headers, timeout=30)
+    if response.status_code != 200:
+        raise SECClientError(f"SEC request failed with status {response.status_code}: {url}")
+    if sleep:
+        time.sleep(sleep)  # be kind to SEC infrastructure
+    return response.json()
+
+
+def _load_ticker_cache() -> Dict[str, TickerInfo]:
+    if not _TICKER_CACHE_FILE.exists():
+        return {}
+    with _TICKER_CACHE_FILE.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return {k: TickerInfo(**v) for k, v in data.items()}
+
+
+def _save_ticker_cache(data: Dict[str, TickerInfo]) -> None:
+    serializable = {k: v.__dict__ for k, v in data.items()}
+    with _TICKER_CACHE_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(serializable, fh)
+
+
+def fetch_ticker_map(force_refresh: bool = False) -> Dict[str, TickerInfo]:
+    """Return a mapping of ticker -> ticker information from the SEC."""
+    cache = _load_ticker_cache()
+    if cache and not force_refresh:
+        return cache
+
+    url = "https://www.sec.gov/files/company_tickers.json"
+    data = _request_json(url)
+    mapping: Dict[str, TickerInfo] = {}
+    for value in data.values():
+        ticker = value["ticker"].upper()
+        mapping[ticker] = TickerInfo(
+            ticker=ticker,
+            cik_str=str(value["cik_str"]),
+            title=value["title"],
+        )
+    _save_ticker_cache(mapping)
+    return mapping
+
+
+def resolve_cik(ticker_or_cik: str, *, force_refresh: bool = False) -> TickerInfo:
+    candidate = ticker_or_cik.strip().upper()
+    if candidate.isdigit() and len(candidate) <= 10:
+        return TickerInfo(ticker=candidate, cik_str=candidate, title="")
+
+    mapping = fetch_ticker_map(force_refresh=force_refresh)
+    if candidate not in mapping:
+        raise KeyError(f"Unknown ticker symbol '{candidate}'.")
+    return mapping[candidate]
+
+
+def fetch_company_facts(cik: str) -> dict:
+    info = resolve_cik(cik)
+    url = f"https://data.sec.gov/api/xbrl/companyfacts/CIK{info.cik}.json"
+    return _request_json(url, sleep=0.4)
+
+
+def fetch_company_submissions(cik: str) -> dict:
+    info = resolve_cik(cik)
+    url = f"https://data.sec.gov/submissions/CIK{info.cik}.json"
+    return _request_json(url, sleep=0.4)
+
+
+def get_company_industry(cik: str) -> IndustryInfo:
+    info = resolve_cik(cik)
+    cache = _load_sic_cache()
+    key = info.cik
+    record = cache.get(key)
+    if record is None:
+        submissions = fetch_company_submissions(info.cik)
+        record = {
+            "sic": submissions.get("sic"),
+            "sic_description": submissions.get("sicDescription"),
+        }
+        cache[key] = record
+        _save_sic_cache(cache)
+    return IndustryInfo(sic=record.get("sic"), description=record.get("sic_description"))
+
+
+def find_industry_peers(
+    cik: str,
+    *,
+    max_companies: int = 5,
+    candidate_pool: Optional[int] = None,
+) -> Tuple[IndustryInfo, List[TickerInfo]]:
+    subject = resolve_cik(cik)
+    industry = get_company_industry(subject.cik)
+    if industry.sic is None:
+        return industry, []
+
+    mapping = fetch_ticker_map()
+    cache = _load_sic_cache()
+    peers: List[TickerInfo] = []
+    updated = False
+
+    if candidate_pool is None:
+        candidate_pool = max(max_companies * 5, max_companies + 5, 20)
+    if max_companies <= 0:
+        candidate_pool = 0
+
+    for candidate in mapping.values():
+        if candidate.cik == subject.cik:
+            continue
+        record = cache.get(candidate.cik)
+        if record is None:
+            try:
+                submissions = fetch_company_submissions(candidate.cik)
+            except SECClientError:
+                continue
+            record = {
+                "sic": submissions.get("sic"),
+                "sic_description": submissions.get("sicDescription"),
+            }
+            cache[candidate.cik] = record
+            updated = True
+        if record.get("sic") == industry.sic:
+            peers.append(candidate)
+        if candidate_pool and len(peers) >= candidate_pool:
+            break
+
+    if updated:
+        _save_sic_cache(cache)
+
+    return industry, peers
+
+
+def fetch_peer_company_facts(
+    cik: str,
+    *,
+    max_companies: int = 5,
+) -> Tuple[IndustryInfo, List[TickerInfo], List[dict]]:
+    if max_companies <= 0:
+        industry, _ = find_industry_peers(cik, max_companies=max_companies)
+        return industry, [], []
+
+    industry, peers = find_industry_peers(
+        cik,
+        max_companies=max_companies,
+        candidate_pool=max(max_companies * 5, max_companies + 5, 20),
+    )
+    peer_facts: List[dict] = []
+    successful_peers: List[TickerInfo] = []
+    for peer in peers:
+        if len(successful_peers) >= max_companies:
+            break
+        try:
+            facts = fetch_company_facts(peer.cik)
+        except SECClientError:
+            continue
+        peer_facts.append(facts)
+        successful_peers.append(peer)
+    return industry, successful_peers, peer_facts
+
+
+def _iter_facts_for_tag(facts: dict, tag: str) -> Iterable[dict]:
+    taxonomy = facts.get("facts", {}).get("us-gaap", {})
+    if tag not in taxonomy:
+        return []
+    tag_info = taxonomy[tag]
+    for units in tag_info.get("units", {}).values():
+        for item in units:
+            yield item
+
+
+def select_fact(
+    facts: dict,
+    tag: str,
+    *,
+    period: str = "annual",
+    forms: Optional[Iterable[str]] = None,
+    reference: Optional[dict] = None,
+) -> Optional[dict]:
+    """Select the most recent fact for ``tag`` matching ``period``."""
+    period = period.lower()
+    if forms is None:
+        forms = ("10-K",) if period == "annual" else ("10-Q", "10-K")
+
+    reference_end = None
+    reference_form = None
+    reference_accn = None
+    reference_fy = None
+    if reference:
+        reference_end = reference.get("end")
+        reference_form = reference.get("form")
+        reference_accn = reference.get("accn")
+        reference_fy = reference.get("fy")
+
+    candidates: List[Tuple[int, datetime, dict]] = []
+    fallback_candidates: List[Tuple[datetime, dict]] = []
+    for item in _iter_facts_for_tag(facts, tag):
+        form = item.get("form")
+        if form not in forms:
+            continue
+        if period == "annual" and item.get("fp") not in {"FY", "Q4", "12M"}:
+            continue
+        if period == "quarterly" and item.get("fp") not in {"Q1", "Q2", "Q3", "Q4"}:
+            continue
+        end = item.get("end")
+        try:
+            end_date = datetime.fromisoformat(end)
+        except (TypeError, ValueError):
+            continue
+        match_score = 0
+        if reference_accn and item.get("accn") == reference_accn:
+            match_score += 100
+        if reference_end and item.get("end") == reference_end:
+            match_score += 20
+        if reference_fy and item.get("fy") == reference_fy:
+            match_score += 10
+        if reference_form and item.get("form") == reference_form:
+            match_score += 1
+        if match_score:
+            candidates.append((match_score, end_date, item))
+        else:
+            fallback_candidates.append((end_date, item))
+
+    if candidates:
+        candidates.sort(key=lambda x: (x[0], x[1]), reverse=True)
+        return candidates[0][2]
+
+    if not fallback_candidates:
+        return None
+    fallback_candidates.sort(key=lambda x: x[0], reverse=True)
+    return fallback_candidates[0][1]
+
+
+def _unit_multiplier(uom: Optional[str]) -> float:
+    if not uom:
+        return 1.0
+    normalized = uom.lower()
+    if "million" in normalized or normalized.endswith("m"):
+        return 1_000_000.0
+    if "thousand" in normalized or normalized.endswith("k"):
+        return 1_000.0
+    return 1.0
+
+
+def extract_value(fact: Optional[dict]) -> Optional[float]:
+    if not fact:
+        return None
+    try:
+        value = float(fact.get("val"))
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return None
+    multiplier = _unit_multiplier(fact.get("uom"))
+    return value * multiplier

--- a/commonize/templates/index.html
+++ b/commonize/templates/index.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Commonize</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+      }
+      body {
+        margin: 0;
+        background: linear-gradient(180deg, #0f172a, #1e293b);
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2rem;
+        color: #e2e8f0;
+      }
+      .card {
+        width: min(960px, 100%);
+        background: rgba(15, 23, 42, 0.92);
+        backdrop-filter: blur(14px);
+        border-radius: 24px;
+        padding: 32px 40px;
+        box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+      }
+      h1 {
+        margin: 0 0 1.25rem 0;
+        font-size: clamp(2rem, 3vw, 3rem);
+        font-weight: 700;
+        letter-spacing: -0.03em;
+      }
+      p.subtitle {
+        margin: 0 0 2rem 0;
+        color: #cbd5f5;
+        font-size: 1rem;
+      }
+      form {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        align-items: end;
+      }
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        font-size: 0.9rem;
+        color: #cbd5f5;
+      }
+      input,
+      select {
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.35);
+        background: rgba(15, 23, 42, 0.65);
+        color: inherit;
+        font-size: 1rem;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+      input:focus,
+      select:focus {
+        outline: none;
+        border-color: #38bdf8;
+        box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+      }
+      button {
+        padding: 0.85rem 1.5rem;
+        border-radius: 999px;
+        border: none;
+        background: linear-gradient(135deg, #38bdf8, #818cf8);
+        color: #0f172a;
+        font-weight: 600;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 24px rgba(56, 189, 248, 0.35);
+      }
+      .results {
+        margin-top: 2.5rem;
+      }
+      .header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        margin-bottom: 1.25rem;
+      }
+      .header h2 {
+        margin: 0;
+        font-size: 1.5rem;
+      }
+      .header span {
+        color: #94a3b8;
+        font-size: 0.95rem;
+      }
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-top: 1.5rem;
+      }
+      .actions a {
+        text-decoration: none;
+        padding: 0.6rem 1.2rem;
+        border-radius: 12px;
+        background: rgba(148, 163, 184, 0.12);
+        color: #38bdf8;
+        font-weight: 600;
+        transition: background 0.2s ease;
+      }
+      .actions a:hover {
+        background: rgba(148, 163, 184, 0.24);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(15, 23, 42, 0.6);
+        border-radius: 16px;
+        overflow: hidden;
+      }
+      thead {
+        background: rgba(148, 163, 184, 0.08);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 0.8rem;
+      }
+      th,
+      td {
+        padding: 0.85rem 1rem;
+        text-align: left;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+      }
+      tbody tr:last-child td {
+        border-bottom: none;
+      }
+      td.line-label {
+        --indent-level: 0;
+        padding-left: calc(1rem + var(--indent-level) * 1.5rem);
+        font-weight: 500;
+        transition: color 0.2s ease;
+      }
+      td.line-label.heading {
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        font-size: 0.75rem;
+        color: #94a3b8;
+      }
+      tr.emphasis td {
+        font-weight: 600;
+        color: #f8fafc;
+      }
+      tr.emphasis td.line-label {
+        color: #f8fafc;
+      }
+      td:nth-child(2),
+      td:nth-child(3),
+      td:nth-child(4) {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+      }
+      .industry-note {
+        margin-top: 0.5rem;
+        color: #94a3b8;
+        font-size: 0.9rem;
+      }
+      .industry-note.pending {
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+        color: #38bdf8;
+      }
+      .error {
+        margin-top: 1.5rem;
+        padding: 1rem 1.25rem;
+        border-radius: 12px;
+        background: rgba(248, 113, 113, 0.12);
+        color: #fecaca;
+        border: 1px solid rgba(248, 113, 113, 0.4);
+      }
+      @media (max-width: 640px) {
+        .card {
+          padding: 24px;
+        }
+        form {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <h1>Commonize</h1>
+      <p class="subtitle">
+        Transform SEC filings into common size statements for quick, visual analysis.
+      </p>
+      <form method="get">
+        <label>
+          Ticker or CIK
+          <input
+            type="text"
+            name="ticker"
+            placeholder="e.g. AAPL"
+            value="{{ ticker }}"
+            required
+            aria-label="Ticker symbol"
+          />
+        </label>
+        <label>
+          Statement
+          <select name="statement" aria-label="Statement">
+            <option value="income" {% if statement == "income" %}selected{% endif %}>
+              Income Statement
+            </option>
+            <option value="balance" {% if statement == "balance" %}selected{% endif %}>
+              Balance Sheet
+            </option>
+          </select>
+        </label>
+        <label>
+          Period
+          <select name="period" aria-label="Period">
+            <option value="annual" {% if period == "annual" %}selected{% endif %}>
+              Annual
+            </option>
+            <option value="quarterly" {% if period == "quarterly" %}selected{% endif %}>
+              Quarterly
+            </option>
+          </select>
+        </label>
+        <button type="submit">Generate</button>
+      </form>
+
+      {% if error %}
+      <div class="error" role="alert">{{ error }}</div>
+      {% endif %}
+
+      {% if rows %}
+      <section class="results" aria-live="polite">
+        <div class="header">
+          <h2>
+            {{ company.title or company.ticker }}
+          </h2>
+          <span>{{ statement_label }} · {{ period_label }}</span>
+        </div>
+        {% if industry and (industry.sic or industry.description) %}
+        <p class="industry-note">
+          Industry average{% if industry.description %}: {{ industry.description }}{% endif %}{% if industry.sic %} (SIC {{ industry.sic }}){% endif %}
+          {% if peer_count %}· derived from {{ peer_count }} peer{{ 's' if peer_count == 1 else 's' }}{% endif %}
+        </p>
+        {% elif peer_count %}
+        <p class="industry-note">Industry average derived from {{ peer_count }} peer{{ 's' if peer_count == 1 else 's' }}.</p>
+        {% endif %}
+        <p class="industry-note">All monetary amounts are presented in USD millions.</p>
+        {% if peer_count == 0 and peers.job and peers.job.status != 'succeeded' %}
+        <p class="industry-note pending" role="status">
+          ⏳ Industry benchmark queued — refresh in a few moments to view the averages.
+        </p>
+        {% endif %}
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Line Item</th>
+              <th scope="col">Value (USD millions)</th>
+              <th scope="col">Company Common Size</th>
+              <th scope="col">Industry Common Size</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in rows %}
+            <tr{% if row.is_emphasis %} class="emphasis"{% endif %}>
+              <td
+                class="line-label{% if row.is_heading %} heading{% endif %}"
+                style="--indent-level: {{ row.indent }}"
+              >
+                {{ row.label }}
+              </td>
+              <td>{{ row.value }}</td>
+              <td>{{ row.percent }}</td>
+              <td>{{ row.industry_percent }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        <div class="actions">
+          <a
+            href="{{ request.url_for('download', file_format='csv') }}?ticker={{ ticker }}&statement={{ statement }}&period={{ period }}"
+            >Download CSV</a
+          >
+          <a
+            href="{{ request.url_for('download', file_format='xlsx') }}?ticker={{ ticker }}&statement={{ statement }}&period={{ period }}"
+            >Download Excel</a
+          >
+        </div>
+      </section>
+      {% endif %}
+    </main>
+  </body>
+</html>

--- a/commonize/web.py
+++ b/commonize/web.py
@@ -1,0 +1,247 @@
+"""FastAPI application for rendering common size financial statements."""
+from __future__ import annotations
+
+from io import BytesIO, StringIO
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Literal
+
+import pandas as pd
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.templating import Jinja2Templates
+
+from .common_size import (
+    CommonSizeLine,
+    StatementNotAvailableError,
+    build_balance_sheet,
+    build_income_statement,
+)
+from .industry_cache import IndustryBenchmark, load_benchmark
+from .industry_jobs import enqueue_benchmark_job, get_job_status
+from .sec_client import (
+    SECClientError,
+    TickerInfo,
+    fetch_company_facts,
+    get_company_industry,
+    resolve_cik,
+)
+
+templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+
+StatementType = Literal["income", "balance"]
+PeriodType = Literal["annual", "quarterly"]
+
+
+_STATEMENT_BUILDERS: Dict[StatementType, Callable[..., List[CommonSizeLine]]] = {
+    "income": build_income_statement,
+    "balance": build_balance_sheet,
+}
+
+_DEFAULT_WEB_PEERS = 10
+
+
+def _format_currency(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value / 1_000_000:,.1f}"
+
+
+def _format_percent(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.1%}"
+
+
+def _apply_cached_industry(
+    lines: List[CommonSizeLine], benchmark: IndustryBenchmark | None
+) -> int:
+    if benchmark is None:
+        return 0
+    for index, ratio in enumerate(benchmark.ratios):
+        if index >= len(lines):
+            break
+        if ratio is None:
+            continue
+        lines[index].industry_common_size = ratio
+    return benchmark.peer_count
+
+
+def _prepare_statement(
+    ticker: str, statement: StatementType, period: PeriodType
+) -> tuple[TickerInfo, List[CommonSizeLine], dict]:
+    builder = _STATEMENT_BUILDERS.get(statement)
+    if builder is None:
+        raise HTTPException(status_code=400, detail="Unsupported statement type")
+
+    info = resolve_cik(ticker)
+    facts = fetch_company_facts(info.cik)
+    industry_info = get_company_industry(info.cik)
+
+    lines = builder(facts, period=period)
+    expected_line_count = len(lines)
+    benchmark = load_benchmark(
+        industry_info.sic,
+        statement,
+        period,
+        expected_line_count=expected_line_count,
+    )
+    peer_count = _apply_cached_industry(lines, benchmark)
+    job_status = None
+
+    if benchmark is None:
+        enqueue_benchmark_job(
+            info,
+            industry_info,
+            statement,
+            period,
+            max_companies=_DEFAULT_WEB_PEERS,
+        )
+        benchmark = load_benchmark(
+            industry_info.sic,
+            statement,
+            period,
+            expected_line_count=expected_line_count,
+        )
+        peer_count = _apply_cached_industry(lines, benchmark)
+        if benchmark is None:
+            job_status = get_job_status(industry_info.sic, statement, period)
+
+    peers_payload = {
+        "industry": industry_info,
+        "peer_count": peer_count,
+        "job": job_status,
+    }
+    return info, lines, peers_payload
+
+
+def _as_dataframe(lines: Iterable[CommonSizeLine]) -> pd.DataFrame:
+    data: List[Dict[str, float | str | int | bool | None]] = []
+    for line in lines:
+        percent = None if line.common_size is None else line.common_size * 100
+        industry_percent = (
+            None if line.industry_common_size is None else line.industry_common_size * 100
+        )
+        value_millions = None if line.value is None else line.value / 1_000_000
+        data.append(
+            {
+                "Label": line.label,
+                "Value (USD)": line.value,
+                "Value (USD millions)": value_millions,
+                "Common Size": line.common_size,
+                "Common Size (%)": percent,
+                "Industry Common Size": line.industry_common_size,
+                "Industry Common Size (%)": industry_percent,
+                "Indent Level": line.indent,
+                "Heading": line.is_header,
+            }
+        )
+    return pd.DataFrame(data)
+
+
+def _format_lines(lines: Iterable[CommonSizeLine]) -> List[Dict[str, str | int | bool]]:
+    formatted: List[Dict[str, str | int | bool]] = []
+    for line in lines:
+        formatted.append(
+            {
+                "label": line.label,
+                "value": _format_currency(line.value),
+                "percent": _format_percent(line.common_size),
+                "industry_percent": _format_percent(line.industry_common_size),
+                "indent": line.indent,
+                "is_heading": line.is_header,
+                "is_emphasis": line.label.lower().startswith("total"),
+            }
+        )
+    return formatted
+
+
+def create_app() -> FastAPI:
+    """Return an application configured to render common size statements."""
+
+    app = FastAPI(title="Commonize", description="Common size financial statements")
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index(
+        request: Request,
+        ticker: str = Query("", description="Ticker symbol or CIK"),
+        statement: StatementType = Query("income", description="Statement to display"),
+        period: PeriodType = Query("annual", description="Periodicity of filings"),
+    ) -> HTMLResponse:
+        context = {
+            "request": request,
+            "ticker": ticker,
+            "statement": statement,
+            "period": period,
+            "company": None,
+            "rows": None,
+            "error": None,
+            "statement_label": "Income Statement" if statement == "income" else "Balance Sheet",
+            "period_label": "Annual" if period == "annual" else "Quarterly",
+            "industry": None,
+            "peer_count": 0,
+            "peers": {},
+        }
+
+        if ticker:
+            try:
+                info, lines, peer_payload = _prepare_statement(ticker, statement, period)
+            except KeyError:
+                context["error"] = f"Unknown ticker symbol '{ticker}'."
+            except StatementNotAvailableError as exc:  # pragma: no cover - error path
+                context["error"] = str(exc)
+            except SECClientError as exc:  # pragma: no cover - network errors
+                context["error"] = str(exc)
+            else:
+                context["company"] = info
+                context["rows"] = _format_lines(lines)
+                context["industry"] = peer_payload.get("industry")
+                context["peer_count"] = peer_payload.get("peer_count", 0)
+                context["peers"] = peer_payload
+
+        return templates.TemplateResponse(request, "index.html", context)
+
+    @app.get("/download/{file_format}")
+    async def download(
+        file_format: Literal["csv", "xlsx"],
+        ticker: str,
+        statement: StatementType = Query("income"),
+        period: PeriodType = Query("annual"),
+    ) -> StreamingResponse:
+        try:
+            info, lines, _ = _prepare_statement(ticker, statement, period)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except StatementNotAvailableError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        filename = f"{info.ticker.lower()}_{statement}_{period}.{file_format}"
+        headers = {"Content-Disposition": f"attachment; filename=\"{filename}\""}
+
+        dataframe = _as_dataframe(lines)
+
+        if file_format == "csv":
+            buffer = StringIO()
+            dataframe.to_csv(buffer, index=False)
+            buffer.seek(0)
+            return StreamingResponse(
+                iter([buffer.getvalue()]), media_type="text/csv", headers=headers
+            )
+
+        if file_format == "xlsx":
+            buffer = BytesIO()
+            with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
+                dataframe.to_excel(writer, index=False, sheet_name="Common Size")
+            buffer.seek(0)
+            return StreamingResponse(
+                buffer,
+                media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                headers=headers,
+            )
+
+        raise HTTPException(status_code=404, detail="Unsupported format")
+
+    return app
+
+
+__all__ = ["create_app"]
+

--- a/commonize/worker.py
+++ b/commonize/worker.py
@@ -1,0 +1,18 @@
+"""Utility entrypoint for running the industry benchmark worker."""
+from __future__ import annotations
+
+import threading
+
+from .industry_jobs import worker_loop
+
+
+def main() -> None:  # pragma: no cover - thin wrapper
+    stop = threading.Event()
+    try:
+        worker_loop(stop)
+    except KeyboardInterrupt:
+        stop.set()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+"""Entry point for the commonize CLI."""
+from commonize import cli_main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(cli_main(None))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+requests>=2.31
+tabulate>=0.9
+fastapi>=0.110
+uvicorn>=0.27
+jinja2>=3.1
+pandas>=2.1
+openpyxl>=3.1
+httpx>=0.27

--- a/tests/test_common_size.py
+++ b/tests/test_common_size.py
@@ -1,0 +1,331 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from commonize import common_size, sec_client
+
+
+def _build_facts(tag_values):
+    return {
+        "facts": {
+            "us-gaap": {
+                tag: {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": value,
+                                "end": "2023-12-31",
+                                "form": form,
+                                "fp": fp,
+                            }
+                            for value, form, fp in values
+                        ]
+                    }
+                }
+                for tag, values in tag_values.items()
+            }
+        }
+    }
+
+
+def test_build_income_statement_computes_percentages():
+    facts = _build_facts(
+        {
+            "Revenues": [(100.0, "10-K", "FY")],
+            "CostOfRevenue": [(40.0, "10-K", "FY")],
+            "GrossProfit": [(60.0, "10-K", "FY")],
+            "ResearchAndDevelopmentExpense": [(10.0, "10-K", "FY")],
+            "SellingGeneralAndAdministrativeExpense": [(20.0, "10-K", "FY")],
+            "OperatingIncomeLoss": [(30.0, "10-K", "FY")],
+            "NetIncomeLoss": [(25.0, "10-K", "FY")],
+        }
+    )
+
+    lines = common_size.build_income_statement(facts)
+
+    assert lines[0].common_size == 1
+    assert lines[-1].common_size == 0.25
+    cost_of_revenue = next(line for line in lines if line.label == "Cost of revenue")
+    assert cost_of_revenue.indent == 1
+    operating_expenses = next(line for line in lines if line.label == "Operating expenses")
+    assert operating_expenses.is_header is True
+
+
+def test_build_income_statement_includes_industry_average():
+    company_facts = _build_facts(
+        {
+            "Revenues": [(200.0, "10-K", "FY")],
+            "CostOfRevenue": [(80.0, "10-K", "FY")],
+            "GrossProfit": [(120.0, "10-K", "FY")],
+        }
+    )
+    peer_one = _build_facts(
+        {
+            "Revenues": [(150.0, "10-K", "FY")],
+            "CostOfRevenue": [(60.0, "10-K", "FY")],
+            "GrossProfit": [(90.0, "10-K", "FY")],
+        }
+    )
+    peer_two = _build_facts(
+        {
+            "Revenues": [(250.0, "10-K", "FY")],
+            "CostOfRevenue": [(125.0, "10-K", "FY")],
+            "GrossProfit": [(125.0, "10-K", "FY")],
+        }
+    )
+
+    lines = common_size.build_income_statement(company_facts, peers=[peer_one, peer_two])
+
+    revenue_line = lines[0]
+    assert revenue_line.industry_common_size == 1
+    cost_of_revenue = next(line for line in lines if line.label == "Cost of revenue")
+    # peer percentages: 0.4 and 0.5 -> average 0.45
+    assert round(cost_of_revenue.industry_common_size or 0, 4) == 0.45
+
+
+def test_missing_denominator_raises():
+    facts = _build_facts({"Revenues": [(0.0, "10-K", "FY")]})
+    try:
+        common_size.build_income_statement(facts)
+    except common_size.StatementNotAvailableError:
+        pass
+    else:
+        raise AssertionError("Expected StatementNotAvailableError")
+
+
+def test_balance_sheet_includes_hierarchical_items():
+    facts = _build_facts(
+        {
+            "Assets": [(200.0, "10-K", "FY")],
+            "Liabilities": [(120.0, "10-K", "FY")],
+            "StockholdersEquity": [(80.0, "10-K", "FY")],
+            "LiabilitiesAndStockholdersEquity": [(200.0, "10-K", "FY")],
+        }
+    )
+
+    lines = common_size.build_balance_sheet(facts)
+
+    assert lines[0].label == "Total assets"
+    assert lines[0].common_size == 1
+    current_assets_header = next(line for line in lines if line.label == "Current assets")
+    assert current_assets_header.is_header is True
+    accounts_payable = next(line for line in lines if line.label == "Accounts payable")
+    assert accounts_payable.indent == 1
+    assert lines[-1].label == "Total liabilities and equity"
+
+
+def test_income_statement_uses_alternative_tags():
+    facts = {
+        "facts": {
+            "us-gaap": {
+                "RevenueFromContractWithCustomerExcludingAssessedTax": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 300_000_000,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                            }
+                        ]
+                    }
+                },
+                "CostOfSales": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 120_000_000,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                            }
+                        ]
+                    }
+                },
+                "GrossProfit": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 180_000_000,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                            }
+                        ]
+                    }
+                },
+            }
+        }
+    }
+
+    lines = common_size.build_income_statement(facts)
+    revenue_line = lines[0]
+    assert revenue_line.value == 300_000_000
+    cost_line = next(line for line in lines if line.label == "Cost of revenue")
+    assert cost_line.value == 120_000_000
+    assert cost_line.as_row()[1] == "120.0"
+
+
+def test_common_size_line_formats_values_in_millions():
+    line = common_size.CommonSizeLine(label="Revenue", value=1_500_000_000.0, common_size=1.0)
+    assert line.as_row()[1] == "1,500.0"
+
+
+def test_extract_value_respects_unit_metadata():
+    fact = {"val": 125.0, "uom": "USDm"}
+    assert sec_client.extract_value(fact) == 125_000_000.0
+
+
+def test_income_statement_derives_missing_values():
+    facts = {
+        "facts": {
+            "us-gaap": {
+                "Revenues": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 200.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            }
+                        ]
+                    }
+                },
+                "GrossProfit": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 80.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            }
+                        ]
+                    }
+                },
+                "OperatingIncomeLoss": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 50.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            }
+                        ]
+                    }
+                },
+                "ResearchAndDevelopmentExpense": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 20.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            }
+                        ]
+                    }
+                },
+                "SellingGeneralAndAdministrativeExpense": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 10.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            }
+                        ]
+                    }
+                },
+                "IncomeTaxExpenseBenefit": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 5.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            }
+                        ]
+                    }
+                },
+                "OtherNonoperatingIncomeExpense": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 3.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            }
+                        ]
+                    }
+                },
+            }
+        }
+    }
+
+    lines = common_size.build_income_statement(facts)
+    lookup = {line.label: line for line in lines}
+
+    assert lookup["Cost of revenue"].value == 120.0
+    assert lookup["Total operating expenses"].value == 30.0
+    assert lookup["Income before taxes"].value == 50.0 + 3.0 - 0.0
+    assert lookup["Net income"].value == 50.0 + 3.0 - 5.0
+
+
+def test_income_statement_respects_reference_context():
+    facts = {
+        "facts": {
+            "us-gaap": {
+                "Revenues": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 400.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            }
+                        ]
+                    }
+                },
+                "CostOfRevenue": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 250.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0002",
+                            },
+                            {
+                                "val": 260.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            },
+                        ]
+                    }
+                },
+            }
+        }
+    }
+
+    lines = common_size.build_income_statement(facts)
+    cost_line = next(line for line in lines if line.label == "Cost of revenue")
+    assert cost_line.value == 260.0

--- a/tests/test_industry_cache.py
+++ b/tests/test_industry_cache.py
@@ -1,0 +1,17 @@
+import importlib
+
+
+def test_store_and_load(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("COMMONIZE_CACHE", str(cache_dir))
+
+    module = importlib.import_module("commonize.industry_cache")
+    importlib.reload(module)
+
+    module.store_benchmark("1234", "income", "annual", [0.1, None], 3, line_count=2)
+    result = module.load_benchmark("1234", "income", "annual", expected_line_count=2)
+
+    assert result is not None
+    assert result.peer_count == 3
+    assert result.ratios == [0.1, None]
+    assert result.line_count == 2

--- a/tests/test_industry_jobs_queue.py
+++ b/tests/test_industry_jobs_queue.py
@@ -1,0 +1,59 @@
+import importlib
+
+from commonize.common_size import CommonSizeLine
+from commonize.sec_client import IndustryInfo, TickerInfo
+
+
+def test_enqueue_and_process_job(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMMONIZE_CACHE", str(tmp_path))
+
+    cache_module = importlib.import_module("commonize.industry_cache")
+    jobs_module = importlib.import_module("commonize.industry_jobs")
+    importlib.reload(cache_module)
+    jobs_module = importlib.reload(jobs_module)
+
+    info = TickerInfo(ticker="DEMO", cik_str="1234", title="Demo Corp")
+    industry = IndustryInfo(sic="5678", description="Demo Industry")
+
+    def fake_builder(facts, *, period="annual", peers=None):
+        line = CommonSizeLine(
+            label="Revenue",
+            value=100.0,
+            common_size=1.0,
+            industry_common_size=None,
+        )
+        if peers:
+            line.industry_common_size = 0.5
+        return [line]
+
+    monkeypatch.setattr(jobs_module, "build_income_statement", fake_builder)
+    jobs_module._JOB_STATEMENTS["income"] = fake_builder
+    monkeypatch.setattr(jobs_module, "fetch_company_facts", lambda cik: {"facts": {}})
+    monkeypatch.setattr(
+        jobs_module,
+        "fetch_peer_company_facts",
+        lambda cik, max_companies=5: (industry, [info], [{"facts": {}}]),
+    )
+
+    jobs_module.enqueue_benchmark_job(
+        info,
+        industry,
+        "income",
+        "annual",
+        max_companies=3,
+    )
+
+    job = jobs_module.claim_next_job()
+    assert job is not None
+    assert job.status == "running"
+
+    jobs_module.process_job(job)
+
+    stored = cache_module.load_benchmark(industry.sic, "income", "annual", expected_line_count=1)
+    assert stored is not None
+    assert stored.peer_count == 1
+    assert stored.ratios[0] == 0.5
+
+    refreshed_job = jobs_module.get_job_status(industry.sic, "income", "annual")
+    assert refreshed_job is not None
+    assert refreshed_job.status == "succeeded"

--- a/tests/test_sec_client.py
+++ b/tests/test_sec_client.py
@@ -1,0 +1,90 @@
+from commonize import sec_client
+
+
+def test_select_fact_prefers_reference_metadata():
+    facts = {
+        "facts": {
+            "us-gaap": {
+                "Revenue": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 100.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            }
+                        ]
+                    }
+                },
+                "Cost": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 70.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0002",
+                            },
+                            {
+                                "val": 65.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            },
+                        ]
+                    }
+                },
+            }
+        }
+    }
+
+    revenue_fact = sec_client.select_fact(facts, "Revenue")
+    assert revenue_fact is not None
+    cost_fact = sec_client.select_fact(
+        facts,
+        "Cost",
+        reference=revenue_fact,
+    )
+    assert cost_fact is not None
+    assert cost_fact.get("accn") == "0001"
+    assert cost_fact.get("val") == 65.0
+
+
+def test_select_fact_falls_back_when_no_reference_match():
+    facts = {
+        "facts": {
+            "us-gaap": {
+                "Metric": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 10.0,
+                                "end": "2022-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                            },
+                            {
+                                "val": 12.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                            },
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+    fact = sec_client.select_fact(
+        facts,
+        "Metric",
+        reference={"end": "2024-12-31", "form": "10-K"},
+    )
+    assert fact is not None
+    # No match on the reference data, so the latest fact should be returned.
+    assert fact.get("end") == "2023-12-31"

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,0 +1,167 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from commonize.common_size import CommonSizeLine, StatementNotAvailableError
+from commonize.industry_cache import IndustryBenchmark
+from commonize.industry_jobs import BenchmarkJob
+from commonize.sec_client import IndustryInfo, TickerInfo
+from commonize import web
+
+
+def _build_lines():
+    return [
+        CommonSizeLine(label="Revenue", value=100_000_000.0, common_size=1.0),
+        CommonSizeLine(label="Net income", value=25_000_000.0, common_size=0.25),
+    ]
+
+
+def _setup_common_mocks(monkeypatch):
+    info = TickerInfo(ticker="DEMO", cik_str="1234", title="Demo Corporation")
+    monkeypatch.setattr(web, "resolve_cik", lambda ticker: info)
+    monkeypatch.setattr(web, "fetch_company_facts", lambda cik: {"facts": {}})
+    industry = IndustryInfo(sic="1234", description="Demo Industry")
+    monkeypatch.setattr(web, "get_company_industry", lambda cik: industry)
+    monkeypatch.setattr(
+        web,
+        "load_benchmark",
+        lambda sic, statement, period, expected_line_count=None: None,
+    )
+    monkeypatch.setattr(web, "enqueue_benchmark_job", lambda *args, **kwargs: None)
+    monkeypatch.setattr(web, "get_job_status", lambda *args, **kwargs: None)
+    monkeypatch.setitem(
+        web._STATEMENT_BUILDERS,
+        "income",
+        lambda facts, *, period="annual", peers=None: _build_lines(),
+    )
+    monkeypatch.setitem(
+        web._STATEMENT_BUILDERS,
+        "balance",
+        lambda facts, *, period="annual", peers=None: _build_lines(),
+    )
+    return info
+
+
+def test_cached_industry_skips_peer_fetch(monkeypatch):
+    info = TickerInfo(ticker="DEMO", cik_str="1234", title="Demo Corporation")
+    industry = IndustryInfo(sic="1234", description="Demo Industry")
+
+    monkeypatch.setattr(web, "resolve_cik", lambda ticker: info)
+    monkeypatch.setattr(web, "fetch_company_facts", lambda cik: {"facts": {}})
+    monkeypatch.setattr(web, "get_company_industry", lambda cik: industry)
+
+    benchmark = IndustryBenchmark(ratios=[1.0, 0.25], peer_count=3, line_count=2, updated_at=0.0)
+    monkeypatch.setattr(
+        web,
+        "load_benchmark",
+        lambda sic, statement, period, expected_line_count=None: benchmark,
+    )
+    def fail_enqueue(*args, **kwargs):
+        raise AssertionError("should not enqueue job when cache is warm")
+
+    monkeypatch.setattr(web, "enqueue_benchmark_job", fail_enqueue)
+    monkeypatch.setattr(web, "get_job_status", lambda *args, **kwargs: None)
+    monkeypatch.setitem(
+        web._STATEMENT_BUILDERS,
+        "income",
+        lambda facts, *, period="annual", peers=None: _build_lines(),
+    )
+
+    client = TestClient(web.create_app())
+    response = client.get("/", params={"ticker": "demo", "statement": "income", "period": "annual"})
+
+    assert response.status_code == 200
+    assert "derived from 3 peers" in response.text
+
+
+def test_index_shows_pending_job(monkeypatch):
+    info = _setup_common_mocks(monkeypatch)
+
+    captured = {}
+
+    def capture_enqueue(*args, **kwargs):
+        captured["called"] = True
+
+    pending_job = BenchmarkJob(
+        sic="1234",
+        statement="income",
+        period="annual",
+        max_companies=5,
+        subject_cik=info.cik,
+        subject_ticker=info.ticker,
+        subject_title=info.title,
+        status="pending",
+        queued_at=0.0,
+        started_at=None,
+        finished_at=None,
+        attempts=0,
+        error=None,
+    )
+
+    monkeypatch.setattr(web, "enqueue_benchmark_job", capture_enqueue)
+    monkeypatch.setattr(web, "get_job_status", lambda *args, **kwargs: pending_job)
+
+    client = TestClient(web.create_app())
+    response = client.get("/", params={"ticker": "demo", "statement": "income", "period": "annual"})
+
+    assert response.status_code == 200
+    assert "Industry benchmark queued" in response.text
+    assert captured.get("called") is True
+
+
+def test_index_renders_statement(monkeypatch):
+    _setup_common_mocks(monkeypatch)
+    client = TestClient(web.create_app())
+
+    response = client.get("/", params={"ticker": "demo", "statement": "income", "period": "annual"})
+
+    assert response.status_code == 200
+    assert "Demo Corporation" in response.text
+    assert "Net income" in response.text
+    assert "25.0" in response.text
+    assert "Industry Common Size" in response.text
+
+
+def test_download_csv(monkeypatch):
+    _setup_common_mocks(monkeypatch)
+    client = TestClient(web.create_app())
+
+    response = client.get("/download/csv", params={"ticker": "demo", "statement": "income", "period": "annual"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "Industry Common Size" in response.text
+    assert "Value (USD millions)" in response.text
+
+
+def test_download_excel(monkeypatch):
+    _setup_common_mocks(monkeypatch)
+    client = TestClient(web.create_app())
+
+    response = client.get("/download/xlsx", params={"ticker": "demo", "statement": "income", "period": "annual"})
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    assert response.content[:2] == b"PK"
+
+
+def test_index_handles_statement_errors(monkeypatch):
+    _setup_common_mocks(monkeypatch)
+
+    def raise_error(*args, **kwargs):
+        raise StatementNotAvailableError("Data unavailable")
+
+    monkeypatch.setitem(
+        web._STATEMENT_BUILDERS,
+        "income",
+        lambda facts, *, period="annual", peers=None: raise_error(),
+    )
+
+    client = TestClient(web.create_app())
+    response = client.get("/", params={"ticker": "demo", "statement": "income", "period": "annual"})
+
+    assert response.status_code == 200
+    assert "Data unavailable" in response.text


### PR DESCRIPTION
## Summary
- anchor common-size extraction to the denominator context and derive connected totals so reported values remain internally consistent with filed statements
- expand SEC peer discovery and fact selection to prefer the same filing metadata and gather a larger candidate pool, improving industry averages across more tickers
- add regression coverage for derived income lines, context-aware selection, and reference-based fact resolution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68db455697408328a30987cd53e8be65