### PR TITLE
Split operating expenses into discrete categories

### DIFF
--- a/commonize/common_size.py
+++ b/commonize/common_size.py
@@ -184,7 +184,8 @@ def _apply_income_derivations(lines: List[CommonSizeLine]) -> None:
     gross = lookup.get("Gross profit")
     revenue = lookup.get("Revenue")
     rd = lookup.get("Research & development")
-    sgna = lookup.get("Selling, general & administrative")
+    sales_marketing = lookup.get("Sales & marketing")
+    general_admin = lookup.get("General & administrative")
     other_ops = lookup.get("Other operating expenses")
     total_ops = lookup.get("Total operating expenses")
     op_income = lookup.get("Operating income")
@@ -195,7 +196,9 @@ def _apply_income_derivations(lines: List[CommonSizeLine]) -> None:
     net_income = lookup.get("Net income")
 
     component_values = [
-        line.value for line in (rd, sgna, other_ops) if line and line.value is not None
+        line.value
+        for line in (rd, sales_marketing, general_admin, other_ops)
+        if line and line.value is not None
     ]
     if total_ops and component_values:
         derived_total = sum(component_values)
@@ -274,8 +277,27 @@ _INCOME_LAYOUT = [
         1,
     ),
     (
-        "Selling, general & administrative",
-        ("SellingGeneralAndAdministrativeExpense", "SellingGeneralAndAdministrativeExpenses"),
+        "Sales & marketing",
+        (
+            "SalesAndMarketingExpense",
+            "SalesAndMarketingExpenses",
+            "SellingAndMarketingExpense",
+            "SellingAndMarketingExpenses",
+            "SalesMarketingExpense",
+            "SalesMarketingExpenses",
+        ),
+        1,
+    ),
+    (
+        "General & administrative",
+        (
+            "GeneralAndAdministrativeExpense",
+            "GeneralAndAdministrativeExpenses",
+            "GeneralAndAdministrativeExpenseNet",
+            "SellingGeneralAndAdministrativeExpense",
+            "SellingGeneralAndAdministrativeExpenses",
+            "SellingGeneralAndAdministrative",
+        ),
         1,
     ),
     (

--- a/tests/test_common_size.py
+++ b/tests/test_common_size.py
@@ -36,7 +36,8 @@ def test_build_income_statement_computes_percentages():
             "CostOfRevenue": [(40.0, "10-K", "FY")],
             "GrossProfit": [(60.0, "10-K", "FY")],
             "ResearchAndDevelopmentExpense": [(10.0, "10-K", "FY")],
-            "SellingGeneralAndAdministrativeExpense": [(20.0, "10-K", "FY")],
+            "SalesAndMarketingExpense": [(12.0, "10-K", "FY")],
+            "GeneralAndAdministrativeExpense": [(8.0, "10-K", "FY")],
             "OperatingIncomeLoss": [(30.0, "10-K", "FY")],
             "NetIncomeLoss": [(25.0, "10-K", "FY")],
         }
@@ -50,6 +51,8 @@ def test_build_income_statement_computes_percentages():
     assert cost_of_revenue.indent == 1
     operating_expenses = next(line for line in lines if line.label == "Operating expenses")
     assert operating_expenses.is_header is True
+    assert any(line.label == "Sales & marketing" for line in lines)
+    assert any(line.label == "General & administrative" for line in lines)
 
 
 def test_build_income_statement_includes_industry_average():
@@ -233,11 +236,24 @@ def test_income_statement_derives_missing_values():
                         ]
                     }
                 },
-                "SellingGeneralAndAdministrativeExpense": {
+                "SalesAndMarketingExpense": {
                     "units": {
                         "USD": [
                             {
-                                "val": 10.0,
+                                "val": 7.0,
+                                "end": "2023-12-31",
+                                "form": "10-K",
+                                "fp": "FY",
+                                "accn": "0001",
+                            }
+                        ]
+                    }
+                },
+                "GeneralAndAdministrativeExpense": {
+                    "units": {
+                        "USD": [
+                            {
+                                "val": 3.0,
                                 "end": "2023-12-31",
                                 "form": "10-K",
                                 "fp": "FY",


### PR DESCRIPTION
## Summary
- split the income statement operating expense layout into research & development, sales & marketing, and general & administrative lines with broader tag coverage
- update operating expense derivations to aggregate the new component categories
- adjust unit tests to reflect the new operating expense categories and ensure they appear in the generated statements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc9252aa94832883f33408ab379c83