### PR TITLE
Add Dockerfile for containerizing FastAPI app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Provide a sensible default for the SEC user agent; override in production
+ENV COMMONIZE_USER_AGENT="CommonizeApp/0.1 (contact@example.com)"
+
+# Expose the FastAPI web server port
+EXPOSE 8000
+
+# Default command runs the web app via uvicorn
+CMD ["uvicorn", "commonize.web:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add a Dockerfile that builds the FastAPI application on Python 3.11
- install system build tools and Python dependencies before copying the app code
- configure uvicorn as the default container entrypoint with a default SEC user agent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc90960c548328a82d58045f030935